### PR TITLE
Amazonページ上の税込を非表示にする機能を追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,6 +19,12 @@ function hidePrices() {
             element.style.display = "none";
         });
     });
+
+    // idを使用して税関連の表示を非表示にする
+    const taxElement = document.getElementById("taxInclusiveMessage");
+    if (taxElement) {
+        taxElement.style.display = "none"; // 税関連のメッセージを非表示にする
+    }
 }
 
 // Run hidePrices whenever the DOM is loaded


### PR DESCRIPTION
Amazonページ上の税込を非表示にする機能を追加しました。具体的な変更点は以下の通りです。

- **税関連メッセージの非表示**: `id="taxInclusiveMessage"`を使用して、税込を非表示にする処理を追加しました。

ご確認お願いいたします。